### PR TITLE
Configure hook and package

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: codecov_validator
+    name: codecov validator
+    description: This hook checks your codecov.yml file
+    entry: ccv
+    language: python
+    types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: codecov_validator
     name: codecov validator
     description: This hook checks your codecov.yml file
-    entry: codecov_validator
+    entry: ccv
     language: python
     types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
--   id: codecov_validator
+-   id: ccv
     name: codecov validator
     description: This hook validates your codecov.yml file
     entry: ccv

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: codecov_validator
     name: codecov validator
     description: This hook checks your codecov.yml file
-    entry: ccv
+    entry: codecov_validator
     language: python
     types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: codecov_validator
     name: codecov validator
-    description: This hook checks your codecov.yml file
+    description: This hook validates your codecov.yml file
     entry: ccv
     language: python
     types: [yaml]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  require_ci_to_pass: yes
+  bot: codecov-bot
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+# https://docs.codecov.io/docs/pull-request-comments#branches
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches:               # branch names that can post comment
+    - "master"

--- a/codecov_validator/__main__.py
+++ b/codecov_validator/__main__.py
@@ -1,3 +1,0 @@
-from . import ccv
-
-ccv.run_request()

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,3 @@ install_requires =
 [options.entry_points]
 console_scripts =
     ccv=codecov_validator.ccv:run_request
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,5 +16,6 @@ classifiers =
 [options]
 python_requires = >=3.8
 
-[console_scripts]
-ccv=codecov_validator.ccv:run_request
+[options.entry_points]
+console_scripts =
+    ccv=codecov_validator.ccv:run_request

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,14 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
+packages = find:
 python_requires = >=3.8
+install_requires =
+    setuptools>=42
+    wheel
+    requests~=2.25.1
 
 [options.entry_points]
 console_scripts =
     ccv=codecov_validator.ccv:run_request
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ classifiers =
 
 [options]
 python_requires = >=3.8
+
+[console_scripts]
+ccv=codecov_validator.ccv:run_request

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
The `.pre-commit-hooks.yaml` is created to allow the usage inside `.pre-commit-config.yaml` files.

The `setup.py` was included to run the `pip install --editable .` to check the package locally, without
uploading and downloading from the remote repository. It also allows the `python setup.py sdist bdist_wheel`
instead of the `python -m build` recommended in [python packaging](https://packaging.python.org/tutorials/packaging-projects/).

The [entrypoint](https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html) was also configured.

A (valid) `codecov.yml` was also included.