### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.2.1
+
+jobs:
+  build-and-test:
+    executor: python/default
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+      - run:
+          command: ./manage.py test
+          name: Test
+
+workflows:
+  main:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,53 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-orbs:
-  python: circleci/python@0.2.1
-
 jobs:
-  build-and-test:
-    executor: python/default
+  build:
+    docker:
+      - image: python:3.8-buster
     steps:
       - checkout
-      - python/load-cache
-      - python/install-deps
-      - python/save-cache
       - run:
-          command: ./manage.py test
-          name: Test
+          name: build package
+          command: |
+              python setup.py sdist bdist_wheel
+      # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
+          # taken to be the root directory of the workspace.
+          root: .
+          # Must be relative path from root
+          paths:
+            - dist
 
+  deploy:
+    docker:
+      - image: python:3.8-buster
+    steps:
+      - checkout
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: .
+      - run:
+          name: pypi upload
+          command: |
+              pip install twine
+              python -m twine upload -u $PYPI_USER -p $PYPI_TOKEN dist/*
+
+# Orchestrate our job run sequence
 workflows:
-  main:
+  build_and_deploy:
     jobs:
-      - build-and-test
+      - build:
+          filters: # required since `deploy` has tag filters AND requires `build`
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+          - build
+          filters:
+            # execute only when tags are created
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![CircleCI](https://circleci.com/gh/circleci/circleci-docs.svg?style=shield)](https://app.circleci.com/pipelines/github/mashi/codecov-validator?branch=main)
 
 
 # Description


### PR DESCRIPTION
The CI was configured following the [examples](https://circleci.com/docs/2.0/workflows/) from the documentation.

In this PR,
- The `build` job runs for all branches and all tags.
- The `deploy` job runs for no branches and only for tags starting with ‘v’.

In other words, it always check if the configuration is valid and if the package can be built, and only
upload when a new tag is created.

Moreover, a `workspace` is also configured to avoid building it twice in two different jobs (`build` and `deploy`).
