### PR TITLE
Ci twine install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 
 jobs:
 
-  packages:
+  twine-package:
     docker:
       - image: python:3.8-buster
     steps:
       - checkout
       - run:
-          name: tests
+          name: twine-package
           command: |
             pip install wheel
             pip install -r requirements-twine.txt
@@ -65,7 +65,7 @@ jobs:
 workflows:
   build_and_deploy:
     jobs:
-      - packages
+      - twine-package
       - test:
           filters: # required since `deploy` has tag filters AND requires `test`
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,21 @@
 version: 2.1
 
 jobs:
+
+  packages:
+    docker:
+      - image: python:3.8-buster
+    steps:
+      - checkout
+      - run:
+          name: tests
+          command: |
+            pip install wheel
+            pip install -r requirements-twine.txt
+
   test:
     docker:
-      - image: python:3.9-buster
+      - image: python:3.8-buster
     steps:
       # adicionar o token do codecov em uma environment variable do circleci chamada de CODECOV_TOKEN
       - checkout
@@ -53,6 +65,7 @@ jobs:
 workflows:
   build_and_deploy:
     jobs:
+      - packages
       - test:
           filters: # required since `deploy` has tag filters AND requires `test`
             tags:


### PR DESCRIPTION
In the current CI file, the `requirements-twine.txt` is executed only when a tag is created and it is sporadically executed. The dependabot may try to update incompatible versions, see PR (#8), which may lead to problems later.

In this PR, the CI is configured to execute `requirements-twine.txt` more often to detect sooner if any incompatible package has been introduced.