### PR TITLE
Refactor exit(1)

### DIFF
--- a/codecov_validator/ccv.py
+++ b/codecov_validator/ccv.py
@@ -1,6 +1,10 @@
 import click
 import requests
 
+# The exit(1) is used to indicate error in pre-commit
+NOT_OK = 1
+OK = 0
+
 
 @click.command()
 @click.option(
@@ -16,17 +20,16 @@ def check_valid(result):
     """
     Check if the message contains the "Valid!" string
     from the request call.
-    The exit(1) is used to indicate an error in the pre-commit.
 
     Args:
         result (str): message to be analyzed.
     """
     if "Valid!" in result:
         print("Valid!")
-        exit(0)
+        exit(OK)
     else:
         print(result)
-        exit(1)
+        exit(NOT_OK)
 
 
 def open_file(filename):
@@ -46,7 +49,7 @@ def open_file(filename):
         return file
     except FileNotFoundError:
         print("Configuration file not found.")
-        exit(1)
+        exit(NOT_OK)
 
 
 def run_request(file):
@@ -69,7 +72,7 @@ def run_request(file):
         requests.exceptions.ConnectionError,
     ):
         print("Failed to establish connection. Check your internet.")
-        exit(1)
+        exit(NOT_OK)
     message = received.content.decode("utf-8")
     return message
 

--- a/tests/test_ccv.py
+++ b/tests/test_ccv.py
@@ -5,6 +5,7 @@ import requests
 from click.testing import CliRunner
 
 from codecov_validator import ccv
+from codecov_validator.ccv import NOT_OK, OK
 
 invalid_file = """
 codecovs:
@@ -52,8 +53,8 @@ class CcvTest(unittest.TestCase):
                 with self.assertRaises(SystemExit) as cm:
                     ccv.run_request(valid_file)
                 # check if the exit(1) was called
-                self.assertEqual(cm.exception.code, 1)
-                self.assertNotEqual(cm.exception.code, 0)
+                self.assertEqual(cm.exception.code, NOT_OK)
+                self.assertNotEqual(cm.exception.code, OK)
 
     def test_run_request_valid_file(self):
         received = ccv.run_request(valid_file)
@@ -67,7 +68,7 @@ class CcvTest(unittest.TestCase):
         invalid_filename = "invalid_codecov.yml"
         with self.assertRaises(SystemExit) as cm:
             ccv.open_file(invalid_filename)
-        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual(cm.exception.code, NOT_OK)
 
     def test_open_file_valid_filename(self):
         right_filename = "codecov.yml"
@@ -78,20 +79,20 @@ class CcvTest(unittest.TestCase):
         valid_input = "Valid!"
         with self.assertRaises(SystemExit) as cm:
             ccv.check_valid(valid_input)
-        self.assertEqual(cm.exception.code, 0)
-        self.assertNotEqual(cm.exception.code, 1)
+        self.assertEqual(cm.exception.code, OK)
+        self.assertNotEqual(cm.exception.code, NOT_OK)
 
     def test_check_valid_invalid_input(self):
         invalid_input = "Invalid!"
         with self.assertRaises(SystemExit) as cm:
             ccv.check_valid(invalid_input)
-        self.assertEqual(cm.exception.code, 1)
-        self.assertNotEqual(cm.exception.code, 0)
+        self.assertEqual(cm.exception.code, NOT_OK)
+        self.assertNotEqual(cm.exception.code, OK)
 
     def test_ccv_valid_clirunner(self):
         runner = CliRunner()
         result = runner.invoke(ccv.ccv)
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, OK)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Usually, `1` represents `True` and `0` represents `False.` However, the `exit(1)` means problems and `exit(0)` means
everything is ok. Variables are renamed to improve readability of the code.