### PR TITLE
Build with version tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: build package
           command: |
-              python setup.py sdist bdist_wheel
+              python -m build
       # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
       - run:
           name: build package
           command: |
+              pip install wheel
+              pip install -r requirements.txt
               python -m build
       # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.
       - persist_to_workspace:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appdirs==1.4.4
+build==0.3.1.post1
 certifi==2020.12.5
 cfgv==3.2.0
 chardet==4.0.0
@@ -11,9 +12,12 @@ identify==2.2.1
 idna==2.10
 mccabe==0.6.1
 nodeenv==1.5.0
+packaging==20.9
+pep517==0.10.0
 pre-commit==2.11.1
 pycodestyle==2.7.0
 pyflakes==2.3.1
+pyparsing==2.4.7
 PyYAML==5.4.1
 requests==2.25.1
 six==1.15.0


### PR DESCRIPTION
The build was not receiving the version tag by the `setuptools_scm`. This PR change the build command to
`python -m build` in order to build the package with the repo tag.