### PR TITLE
Fix hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
     entry: ccv
     language: python
     types: [yaml]
+    pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The recommended use is to add in the `.pre-commit-config.yaml` file
   rev: v0.0.1  # replace by any tag version available
   hooks:
     - id: ccv
+      # args: [--filename, .codecov.yml]  # example with arguments
 ```
 
 In this way, the `codecov.yml` file is checked before `commit` and prevents the user


### PR DESCRIPTION
Using the pre-commit in other project as
```
  - repo: https://github.com/mashi/codecov-validator
    rev: v0.0.2
    hooks:
      - id: ccv
```

an error was returned:
```
$ pre-commit run ccv
codecov validator........................................................Failed
- hook id: ccv
- exit code: 2

Usage: ccv [OPTIONS]
Try 'ccv --help' for help.

Error: Got unexpected extra arguments (.pre-commit-config.yaml codecov.yml)
```

The option `pass_filenames` was included to fix this.