### PR TITLE
Coverage threshold

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,3 +72,8 @@ repos:
       # Trims trailing whitespace.
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/mashi/codecov-validator
+    rev: v1.0.0
+    hooks:
+      - id: ccv

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,11 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
 
 parsers:
   gcov:


### PR DESCRIPTION
Include the threshold option, from the [docs](https://docs.codecov.io/docs/commit-status): allow the coverage to drop by X%, and posting a success status.